### PR TITLE
feat(cli): implement interactive menu with Inquirer + Rich (Issue #6)

### DIFF
--- a/src/lms/cli.py
+++ b/src/lms/cli.py
@@ -1,0 +1,129 @@
+"""CLI module for SkillOps LMS - Interactive menu system.
+
+This module provides the main interactive CLI menu using Inquirer for keyboard
+navigation and Rich for visual display.
+"""
+
+from typing import Optional
+import inquirer
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+console = Console()
+
+
+class Step:
+    """Represents a step in the LMS workflow."""
+
+    def __init__(self, number: int, name: str, emoji: str, completed: bool = False):
+        self.number = number
+        self.name = name
+        self.emoji = emoji
+        self.completed = completed
+
+    def __str__(self) -> str:
+        status = "●" if self.completed else "○"
+        return f"{self.emoji} {self.number}. {self.name} {status}"
+
+
+# Define the 8 steps of the LMS workflow
+STEPS = [
+    Step(1, "Review", "📊"),
+    Step(2, "Formation", "⏱️"),
+    Step(3, "Anki", "🗂️"),
+    Step(4, "Create", "📝"),
+    Step(5, "Read", "📖"),
+    Step(6, "Reinforce", "💪"),
+    Step(7, "Share", "🌐"),
+    Step(8, "Reflection", "🌅"),
+]
+
+
+def display_header() -> None:
+    """Display the SkillOps header with Rich formatting."""
+    header_text = Text("SkillOps LMS", style="bold cyan", justify="center")
+    subtitle = Text(
+        "Your Daily Learning Management System", style="dim", justify="center"
+    )
+
+    panel = Panel(
+        f"{header_text}\n{subtitle}",
+        title="Welcome",
+        border_style="cyan",
+        padding=(1, 2),
+    )
+    console.print(panel)
+    console.print()
+
+
+def get_step_choices() -> list[str]:
+    """Generate the list of step choices for the menu.
+
+    Returns:
+        List of formatted step strings with visual indicators.
+    """
+    choices = [str(step) for step in STEPS]
+    choices.append("❌ Exit")
+    return choices
+
+
+def main_menu() -> Optional[Step]:
+    """Display the main interactive menu and return the selected step.
+
+    Uses Inquirer for keyboard navigation with arrow keys.
+    Returns None if user selects Exit.
+
+    Returns:
+        The selected Step object, or None if Exit was chosen.
+    """
+    display_header()
+
+    choices = get_step_choices()
+
+    questions = [
+        inquirer.List(
+            "step",
+            message="Select a step to execute (use arrow keys)",
+            choices=choices,
+            carousel=True,
+        )
+    ]
+
+    try:
+        answers = inquirer.prompt(questions)
+
+        if answers is None or answers["step"] == "❌ Exit":
+            console.print("\n[yellow]Goodbye! Keep learning! 🚀[/yellow]\n")
+            return None
+
+        # Extract step number from selection
+        selected_text = answers["step"]
+        step_number = int(selected_text.split(".")[0].split()[-1])
+
+        # Find and return the corresponding Step object
+        for step in STEPS:
+            if step.number == step_number:
+                return step
+
+        return None
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted by user. Goodbye! 👋[/yellow]\n")
+        return None
+
+
+def execute_step(step: Step) -> None:
+    """Execute a specific step.
+
+    This is a placeholder that will be implemented with actual step logic.
+
+    Args:
+        step: The Step object to execute.
+    """
+    console.print(
+        f"\n[green]Executing {step.emoji} {step.name}...[/green]", style="bold"
+    )
+    console.print(
+        f"[dim]Step {step.number} implementation coming soon...[/dim]\n"
+    )

--- a/src/lms/main.py
+++ b/src/lms/main.py
@@ -1,2 +1,30 @@
+"""Main entry point for SkillOps LMS CLI application."""
+
+import typer
+from lms.cli import main_menu, execute_step
+
+app = typer.Typer(
+    name="skillops",
+    help="SkillOps - Your Daily Learning Management System",
+    add_completion=False,
+)
+
+
+@app.command()
+def start():
+    """Start the interactive SkillOps LMS menu."""
+    while True:
+        step = main_menu()
+        if step is None:
+            break
+        execute_step(step)
+
+
+@app.command()
+def version():
+    """Display the SkillOps version."""
+    typer.echo("SkillOps LMS v0.1.0 (Sprint 1 MVP)")
+
+
 if __name__ == "__main__":
-    pass
+    app()

--- a/tests/lms/cli_test.py
+++ b/tests/lms/cli_test.py
@@ -1,0 +1,266 @@
+"""Tests for the CLI module - main menu and step navigation."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from lms.cli import (
+    Step,
+    STEPS,
+    main_menu,
+    execute_step,
+    get_step_choices,
+    display_header,
+)
+
+
+class TestStep:
+    """Tests for the Step class."""
+
+    def test_step_initialization(self):
+        """
+        Given: Step parameters
+        When: Creating a new Step instance
+        Then: All attributes are set correctly
+        """
+        step = Step(1, "Review", "📊", completed=True)
+
+        assert step.number == 1
+        assert step.name == "Review"
+        assert step.emoji == "📊"
+        assert step.completed is True
+
+    def test_step_str_completed(self):
+        """
+        Given: A completed step
+        When: Converting to string
+        Then: String contains filled circle (●)
+        """
+        step = Step(1, "Review", "📊", completed=True)
+        result = str(step)
+
+        assert "●" in result
+        assert "Review" in result
+        assert "📊" in result
+
+    def test_step_str_not_completed(self):
+        """
+        Given: An incomplete step
+        When: Converting to string
+        Then: String contains empty circle (○)
+        """
+        step = Step(2, "Formation", "⏱️", completed=False)
+        result = str(step)
+
+        assert "○" in result
+        assert "Formation" in result
+        assert "⏱️" in result
+
+
+class TestStepChoices:
+    """Tests for step choice generation."""
+
+    def test_get_step_choices_length(self):
+        """
+        Given: The predefined STEPS list
+        When: Getting step choices
+        Then: Returns 8 steps + Exit option = 9 choices
+        """
+        choices = get_step_choices()
+
+        assert len(choices) == 9
+        assert "❌ Exit" in choices
+
+    def test_get_step_choices_format(self):
+        """
+        Given: The predefined STEPS list
+        When: Getting step choices
+        Then: Each choice contains emoji and step name
+        """
+        choices = get_step_choices()
+
+        # Check first step format
+        assert "📊" in choices[0]
+        assert "Review" in choices[0]
+
+        # Check last step format (before Exit)
+        assert "🌅" in choices[7]
+        assert "Reflection" in choices[7]
+
+
+class TestDisplayHeader:
+    """Tests for header display."""
+
+    @patch("lms.cli.console.print")
+    def test_display_header_calls_print(self, mock_print):
+        """
+        Given: Console is available
+        When: Displaying header
+        Then: Console.print is called
+        """
+        display_header()
+
+        assert mock_print.call_count >= 2
+
+
+class TestMainMenu:
+    """Tests for the main menu interaction."""
+
+    @patch("lms.cli.inquirer.prompt")
+    @patch("lms.cli.console.print")
+    def test_main_menu_returns_none_on_exit(self, mock_print, mock_prompt):
+        """
+        Given: User selects Exit option
+        When: Displaying main menu
+        Then: Returns None
+        """
+        mock_prompt.return_value = {"step": "❌ Exit"}
+
+        result = main_menu()
+
+        assert result is None
+        mock_prompt.assert_called_once()
+
+    @patch("lms.cli.inquirer.prompt")
+    def test_main_menu_returns_step_on_selection(self, mock_prompt):
+        """
+        Given: User selects step 1 (Review)
+        When: Displaying main menu
+        Then: Returns the corresponding Step object
+        """
+        mock_prompt.return_value = {"step": "📊 1. Review ○"}
+
+        result = main_menu()
+
+        assert result is not None
+        assert result.number == 1
+        assert result.name == "Review"
+        assert result.emoji == "📊"
+
+    @patch("lms.cli.inquirer.prompt")
+    @patch("lms.cli.console.print")
+    def test_main_menu_handles_keyboard_interrupt(self, mock_print, mock_prompt):
+        """
+        Given: User presses Ctrl+C
+        When: Displaying main menu
+        Then: Returns None and displays goodbye message
+        """
+        mock_prompt.side_effect = KeyboardInterrupt()
+
+        result = main_menu()
+
+        assert result is None
+
+    @patch("lms.cli.inquirer.prompt")
+    @patch("lms.cli.console.print")
+    def test_main_menu_handles_none_answer(self, mock_print, mock_prompt):
+        """
+        Given: Prompt returns None (Ctrl+D or similar)
+        When: Displaying main menu
+        Then: Returns None
+        """
+        mock_prompt.return_value = None
+
+        result = main_menu()
+
+        assert result is None
+
+    @patch("lms.cli.inquirer.prompt")
+    def test_main_menu_multiple_steps(self, mock_prompt):
+        """
+        Given: User selects different steps
+        When: Calling main_menu multiple times
+        Then: Returns correct Step for each selection
+        """
+        # Test step 3 (Anki)
+        mock_prompt.return_value = {"step": "🗂️ 3. Anki ○"}
+        result = main_menu()
+        assert result.number == 3
+        assert result.name == "Anki"
+
+        # Test step 8 (Reflection)
+        mock_prompt.return_value = {"step": "🌅 8. Reflection ○"}
+        result = main_menu()
+        assert result.number == 8
+        assert result.name == "Reflection"
+
+
+class TestExecuteStep:
+    """Tests for step execution."""
+
+    @patch("lms.cli.console.print")
+    def test_execute_step_displays_message(self, mock_print):
+        """
+        Given: A valid step
+        When: Executing the step
+        Then: Console displays execution message
+        """
+        step = Step(1, "Review", "📊")
+
+        execute_step(step)
+
+        assert mock_print.call_count >= 2
+
+    @patch("lms.cli.console.print")
+    def test_execute_step_includes_emoji(self, mock_print):
+        """
+        Given: A step with emoji
+        When: Executing the step
+        Then: Emoji is included in the output
+        """
+        step = Step(2, "Formation", "⏱️")
+
+        execute_step(step)
+
+        # Check that at least one call contains the emoji
+        calls_str = str(mock_print.call_args_list)
+        assert "⏱️" in calls_str or "Formation" in calls_str
+
+
+class TestStepsConstants:
+    """Tests for the STEPS constant."""
+
+    def test_steps_has_eight_items(self):
+        """
+        Given: The STEPS constant
+        When: Checking length
+        Then: Contains exactly 8 steps
+        """
+        assert len(STEPS) == 8
+
+    def test_steps_sequential_numbers(self):
+        """
+        Given: The STEPS constant
+        When: Checking step numbers
+        Then: Numbers are sequential from 1 to 8
+        """
+        for i, step in enumerate(STEPS, start=1):
+            assert step.number == i
+
+    def test_steps_all_have_emojis(self):
+        """
+        Given: The STEPS constant
+        When: Checking each step
+        Then: All steps have emojis defined
+        """
+        for step in STEPS:
+            assert step.emoji
+            assert len(step.emoji) > 0
+
+    def test_steps_all_have_names(self):
+        """
+        Given: The STEPS constant
+        When: Checking each step
+        Then: All steps have names defined
+        """
+        expected_names = [
+            "Review",
+            "Formation",
+            "Anki",
+            "Create",
+            "Read",
+            "Reinforce",
+            "Share",
+            "Reflection",
+        ]
+
+        for i, step in enumerate(STEPS):
+            assert step.name == expected_names[i]


### PR DESCRIPTION
## Description
Implémentation du menu principal interactif avec navigation au clavier.

## Changes
- Add `cli.py` with Step class and `main_menu()` using Inquirer navigation
- Update `main.py` with Typer app and start command
- Add 17 unit tests (98% coverage on cli.py)
- Display 8 steps with emojis and completion indicators
- Keyboard navigation with arrow keys
- Exit option with goodbye message

## Testing
- 17 tests passing
- 98% code coverage on `lms/cli.py`

## Resolves
Closes #6