### PR TITLE
feat(formation): Intégration WakaTime (Issue #13)

### DIFF
--- a/src/lms/api_clients/__init__.py
+++ b/src/lms/api_clients/__init__.py
@@ -1,6 +1,6 @@
 """API clients package."""
 
-from lms.api_clients.wakatime_client import (
+from src.lms.api_clients.wakatime_client import (
     WakaTimeClient,
     WakaTimeError,
     WakaTimeAuthError,

--- a/src/lms/main.py
+++ b/src/lms/main.py
@@ -1,7 +1,7 @@
 """Main entry point for SkillOps LMS CLI application."""
 
 import typer
-from lms.cli import main_menu, execute_step
+from src.lms.cli import main_menu, execute_step
 
 app = typer.Typer(
     name="skillops",

--- a/src/lms/steps/__init__.py
+++ b/src/lms/steps/__init__.py
@@ -1,6 +1,7 @@
 """Steps module - Contains all LMS workflow steps."""
 
-from lms.steps.review import review_step
+from src.lms.steps.formation import formation_step
+from src.lms.steps.review import review_step
 
-__all__ = ["review_step"]
+__all__ = ["formation_step", "review_step"]
 

--- a/src/lms/steps/formation.py
+++ b/src/lms/steps/formation.py
@@ -1,0 +1,194 @@
+"""Étape Formation - Affichage des statistiques de temps de code WakaTime."""
+
+import os
+from datetime import datetime, time
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ..api_clients.wakatime_client import WakaTimeClient, WakaTimeError
+from ..display import (
+    display_error_message,
+    display_info_panel,
+    display_section_header,
+    display_success_message,
+    display_warning_message,
+    format_time_duration,
+)
+
+console = Console()
+
+# Configuration
+MINIMUM_DAILY_HOURS = 2
+ALERT_TIME_HOUR = 17  # 17h
+
+
+def get_api_key_from_env() -> Optional[str]:
+    """
+    Récupère la clé API WakaTime depuis les variables d'environnement.
+
+    Returns:
+        Optional[str]: La clé API ou None si non trouvée
+    """
+    return os.getenv("WAKATIME_API_KEY")
+
+
+def should_show_alert(current_time: datetime, hours_coded: float) -> bool:
+    """
+    Détermine si une alerte doit être affichée.
+
+    Une alerte est affichée si:
+    - Il est avant l'heure limite (17h)
+    - Le temps de code est inférieur au minimum requis
+
+    Args:
+        current_time: Heure actuelle
+        hours_coded: Nombre d'heures de code aujourd'hui
+
+    Returns:
+        bool: True si l'alerte doit être affichée
+    """
+    is_before_deadline = current_time.hour < ALERT_TIME_HOUR
+    below_minimum = hours_coded < MINIMUM_DAILY_HOURS
+    return is_before_deadline and below_minimum
+
+
+def create_stats_table(stats: dict) -> Table:
+    """
+    Crée un tableau Rich pour afficher les statistiques WakaTime.
+
+    Args:
+        stats: Dictionnaire avec les statistiques (total_seconds, languages, categories)
+
+    Returns:
+        Table: Tableau Rich avec les statistiques formatées
+    """
+    table = Table(title="📊 Statistiques du jour", show_header=True, header_style="bold cyan")
+    table.add_column("Métrique", style="cyan", width=20)
+    table.add_column("Valeur", style="green", width=30)
+
+    # Temps total
+    total_seconds = stats.get("total_seconds", 0)
+    formatted_time = format_time_duration(total_seconds)
+    table.add_row("⏱️ Temps total", formatted_time)
+
+    # Langages
+    languages = stats.get("languages", [])
+    if languages:
+        top_language = languages[0]
+        lang_name = top_language.get("name", "N/A")
+        lang_time = format_time_duration(top_language.get("total_seconds", 0))
+        table.add_row("💻 Langage principal", f"{lang_name} ({lang_time})")
+
+    # Catégories
+    categories = stats.get("categories", [])
+    if categories:
+        top_category = categories[0]
+        cat_name = top_category.get("name", "N/A")
+        cat_time = format_time_duration(top_category.get("total_seconds", 0))
+        table.add_row("📁 Catégorie principale", f"{cat_name} ({cat_time})")
+
+    return table
+
+
+def create_languages_table(languages: list) -> Table:
+    """
+    Crée un tableau détaillé des langages utilisés.
+
+    Args:
+        languages: Liste des langages avec leurs statistiques
+
+    Returns:
+        Table: Tableau Rich avec les langages
+    """
+    table = Table(title="💻 Langages utilisés", show_header=True, header_style="bold magenta")
+    table.add_column("Langage", style="magenta", width=20)
+    table.add_column("Temps", style="cyan", width=15)
+    table.add_column("Pourcentage", style="green", width=15)
+
+    for lang in languages[:5]:  # Top 5
+        name = lang.get("name", "N/A")
+        time_str = format_time_duration(lang.get("total_seconds", 0))
+        percent = lang.get("percent", 0)
+        table.add_row(name, time_str, f"{percent:.1f}%")
+
+    return table
+
+
+def formation_step(storage_path: Optional[Path] = None) -> None:
+    """
+    Exécute l'étape Formation : affiche les statistiques WakaTime du jour.
+
+    Cette fonction:
+    1. Récupère la clé API WakaTime
+    2. Interroge l'API pour les stats du jour
+    3. Affiche un résumé des statistiques
+    4. Affiche une alerte si le temps de code est insuffisant (< 2h avant 17h)
+    5. Affiche les langages utilisés
+
+    Args:
+        storage_path: Chemin vers le répertoire de stockage (non utilisé pour l'instant)
+
+    Raises:
+        WakaTimeError: En cas d'erreur avec l'API WakaTime
+    """
+    display_section_header("Formation", "📚")
+
+    # Récupérer la clé API
+    api_key = get_api_key_from_env()
+    if not api_key:
+        display_error_message(
+            "Clé API WakaTime introuvable",
+            "Veuillez définir la variable d'environnement WAKATIME_API_KEY.\n"
+            "Consultez le README pour les instructions de configuration.",
+        )
+        return
+
+    try:
+        # Initialiser le client WakaTime
+        client = WakaTimeClient(api_key)
+
+        # Récupérer les stats du jour
+        display_info_panel("WakaTime", "Récupération des statistiques...")
+        stats = client.get_today_stats()
+
+        # Afficher le tableau de statistiques
+        console.print()
+        stats_table = create_stats_table(stats)
+        console.print(stats_table)
+
+        # Calculer les heures de code
+        total_seconds = stats.get("total_seconds", 0)
+        hours_coded = total_seconds / 3600
+
+        # Vérifier si une alerte doit être affichée
+        current_time = datetime.now()
+        if should_show_alert(current_time, hours_coded):
+            remaining_hours = MINIMUM_DAILY_HOURS - hours_coded
+            display_warning_message(
+                f"⚠️ Objectif quotidien non atteint",
+                f"Il vous reste {remaining_hours:.1f}h à coder avant 17h pour atteindre "
+                f"l'objectif de {MINIMUM_DAILY_HOURS}h.",
+            )
+        else:
+            if hours_coded >= MINIMUM_DAILY_HOURS:
+                display_success_message(
+                    "🎉 Objectif quotidien atteint !",
+                    f"Vous avez codé {hours_coded:.1f}h aujourd'hui. Excellent travail !",
+                )
+
+        # Afficher les langages si disponibles
+        languages = stats.get("languages", [])
+        if languages:
+            console.print()
+            languages_table = create_languages_table(languages)
+            console.print(languages_table)
+
+        console.print()
+
+    except WakaTimeError as e:
+        display_error_message("Erreur WakaTime", str(e))
+        raise

--- a/src/lms/steps/review.py
+++ b/src/lms/steps/review.py
@@ -6,8 +6,8 @@ including completed steps, time coded, cards created, and current streak.
 
 from pathlib import Path
 from datetime import datetime, timedelta
-from lms.persistence import MetricsManager, ProgressManager
-from lms.display import (
+from src.lms.persistence import MetricsManager, ProgressManager
+from src.lms.display import (
     create_metrics_table,
     create_step_summary_table,
     display_section_header,

--- a/tests/lms/steps/formation_test.py
+++ b/tests/lms/steps/formation_test.py
@@ -1,0 +1,372 @@
+"""Tests pour l'étape Formation."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.table import Table
+
+from src.lms.api_clients.wakatime_client import WakaTimeAuthError, WakaTimeError
+from src.lms.steps.formation import (
+    create_languages_table,
+    create_stats_table,
+    formation_step,
+    get_api_key_from_env,
+    should_show_alert,
+)
+
+
+class TestGetApiKeyFromEnv:
+    """Tests pour get_api_key_from_env()."""
+
+    def test_returns_api_key_when_present(self, monkeypatch):
+        """
+        Given: Variable d'environnement WAKATIME_API_KEY définie
+        When: Appel de get_api_key_from_env()
+        Then: Retourne la clé API
+        """
+        monkeypatch.setenv("WAKATIME_API_KEY", "test-key-123")
+        result = get_api_key_from_env()
+        assert result == "test-key-123"
+
+    def test_returns_none_when_absent(self, monkeypatch):
+        """
+        Given: Variable d'environnement WAKATIME_API_KEY non définie
+        When: Appel de get_api_key_from_env()
+        Then: Retourne None
+        """
+        monkeypatch.delenv("WAKATIME_API_KEY", raising=False)
+        result = get_api_key_from_env()
+        assert result is None
+
+
+class TestShouldShowAlert:
+    """Tests pour should_show_alert()."""
+
+    def test_shows_alert_before_deadline_below_minimum(self):
+        """
+        Given: Il est 15h et 1.5h de code
+        When: Appel de should_show_alert()
+        Then: Retourne True
+        """
+        current_time = datetime(2024, 1, 15, 15, 0)  # 15h
+        hours_coded = 1.5
+        assert should_show_alert(current_time, hours_coded) is True
+
+    def test_no_alert_before_deadline_above_minimum(self):
+        """
+        Given: Il est 15h et 2.5h de code
+        When: Appel de should_show_alert()
+        Then: Retourne False
+        """
+        current_time = datetime(2024, 1, 15, 15, 0)  # 15h
+        hours_coded = 2.5
+        assert should_show_alert(current_time, hours_coded) is False
+
+    def test_no_alert_after_deadline_below_minimum(self):
+        """
+        Given: Il est 18h et 1h de code
+        When: Appel de should_show_alert()
+        Then: Retourne False (trop tard pour l'alerte)
+        """
+        current_time = datetime(2024, 1, 15, 18, 0)  # 18h
+        hours_coded = 1.0
+        assert should_show_alert(current_time, hours_coded) is False
+
+    def test_no_alert_at_deadline_below_minimum(self):
+        """
+        Given: Il est exactement 17h et 1h de code
+        When: Appel de should_show_alert()
+        Then: Retourne False (deadline atteinte)
+        """
+        current_time = datetime(2024, 1, 15, 17, 0)  # 17h
+        hours_coded = 1.0
+        assert should_show_alert(current_time, hours_coded) is False
+
+    def test_no_alert_before_deadline_at_minimum(self):
+        """
+        Given: Il est 15h et exactement 2h de code
+        When: Appel de should_show_alert()
+        Then: Retourne False (objectif atteint)
+        """
+        current_time = datetime(2024, 1, 15, 15, 0)  # 15h
+        hours_coded = 2.0
+        assert should_show_alert(current_time, hours_coded) is False
+
+
+class TestCreateStatsTable:
+    """Tests pour create_stats_table()."""
+
+    def test_creates_table_with_complete_stats(self):
+        """
+        Given: Statistiques complètes (temps, langages, catégories)
+        When: Appel de create_stats_table()
+        Then: Crée une table Rich avec toutes les données
+        """
+        stats = {
+            "total_seconds": 7200,  # 2h
+            "languages": [{"name": "Python", "total_seconds": 5400, "percent": 75.0}],
+            "categories": [{"name": "Coding", "total_seconds": 6400, "percent": 88.9}],
+        }
+        table = create_stats_table(stats)
+        assert isinstance(table, Table)
+        assert table.title == "📊 Statistiques du jour"
+        assert len(table.columns) == 2
+
+    def test_creates_table_with_minimal_stats(self):
+        """
+        Given: Statistiques minimales (seulement temps total)
+        When: Appel de create_stats_table()
+        Then: Crée une table avec uniquement le temps
+        """
+        stats = {"total_seconds": 3600}  # 1h
+        table = create_stats_table(stats)
+        assert isinstance(table, Table)
+        assert len(table.columns) == 2
+
+    def test_creates_table_with_zero_time(self):
+        """
+        Given: Statistiques avec 0 seconde
+        When: Appel de create_stats_table()
+        Then: Crée une table avec "0min"
+        """
+        stats = {"total_seconds": 0}
+        table = create_stats_table(stats)
+        assert isinstance(table, Table)
+
+    def test_creates_table_with_empty_languages(self):
+        """
+        Given: Statistiques sans langages
+        When: Appel de create_stats_table()
+        Then: Crée une table sans ligne de langage
+        """
+        stats = {"total_seconds": 3600, "languages": []}
+        table = create_stats_table(stats)
+        assert isinstance(table, Table)
+
+
+class TestCreateLanguagesTable:
+    """Tests pour create_languages_table()."""
+
+    def test_creates_table_with_languages(self):
+        """
+        Given: Liste de langages avec statistiques
+        When: Appel de create_languages_table()
+        Then: Crée une table Rich avec les langages
+        """
+        languages = [
+            {"name": "Python", "total_seconds": 5400, "percent": 60.0},
+            {"name": "JavaScript", "total_seconds": 3600, "percent": 40.0},
+        ]
+        table = create_languages_table(languages)
+        assert isinstance(table, Table)
+        assert table.title == "💻 Langages utilisés"
+        assert len(table.columns) == 3
+
+    def test_limits_to_top_5_languages(self):
+        """
+        Given: Liste de 10 langages
+        When: Appel de create_languages_table()
+        Then: Table contient seulement les 5 premiers
+        """
+        languages = [
+            {"name": f"Lang{i}", "total_seconds": 1000 - i * 100, "percent": 10.0}
+            for i in range(10)
+        ]
+        table = create_languages_table(languages)
+        assert isinstance(table, Table)
+        # Vérifier qu'on a bien une table (pas de moyen direct de compter les rows)
+
+    def test_creates_table_with_empty_list(self):
+        """
+        Given: Liste vide de langages
+        When: Appel de create_languages_table()
+        Then: Crée une table vide
+        """
+        languages = []
+        table = create_languages_table(languages)
+        assert isinstance(table, Table)
+
+
+class TestFormationStep:
+    """Tests pour formation_step()."""
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    @patch("src.lms.steps.formation.datetime")
+    def test_displays_stats_successfully(self, mock_datetime, mock_get_key, mock_client_class):
+        """
+        Given: Clé API valide et statistiques disponibles
+        When: Appel de formation_step()
+        Then: Affiche les statistiques et pas d'alerte si objectif atteint
+        """
+        # Setup
+        mock_get_key.return_value = "test-key"
+        mock_datetime.now.return_value = datetime(2024, 1, 15, 15, 0)
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.return_value = {
+            "total_seconds": 7200,  # 2h
+            "languages": [{"name": "Python", "total_seconds": 5400, "percent": 75.0}],
+            "categories": [{"name": "Coding", "total_seconds": 6400, "percent": 88.9}],
+        }
+
+        # Execute
+        formation_step()
+
+        # Verify
+        mock_get_key.assert_called_once()
+        mock_client_class.assert_called_once_with("test-key")
+        mock_client.get_today_stats.assert_called_once()
+
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    def test_shows_error_when_no_api_key(self, mock_get_key):
+        """
+        Given: Aucune clé API disponible
+        When: Appel de formation_step()
+        Then: Affiche un message d'erreur et retourne sans appeler l'API
+        """
+        mock_get_key.return_value = None
+
+        # Should not raise exception, just display error
+        formation_step()
+
+        mock_get_key.assert_called_once()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    @patch("src.lms.steps.formation.datetime")
+    def test_shows_alert_when_below_minimum(self, mock_datetime, mock_get_key, mock_client_class):
+        """
+        Given: 1h de code à 15h (en dessous du minimum)
+        When: Appel de formation_step()
+        Then: Affiche une alerte
+        """
+        mock_get_key.return_value = "test-key"
+        mock_datetime.now.return_value = datetime(2024, 1, 15, 15, 0)
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.return_value = {
+            "total_seconds": 3600,  # 1h
+            "languages": [],
+            "categories": [],
+        }
+
+        formation_step()
+
+        mock_client.get_today_stats.assert_called_once()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    @patch("src.lms.steps.formation.datetime")
+    def test_no_alert_after_deadline(self, mock_datetime, mock_get_key, mock_client_class):
+        """
+        Given: 1h de code à 18h (après deadline)
+        When: Appel de formation_step()
+        Then: Pas d'alerte affichée
+        """
+        mock_get_key.return_value = "test-key"
+        mock_datetime.now.return_value = datetime(2024, 1, 15, 18, 0)
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.return_value = {
+            "total_seconds": 3600,  # 1h
+            "languages": [],
+            "categories": [],
+        }
+
+        formation_step()
+
+        mock_client.get_today_stats.assert_called_once()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    def test_raises_error_on_api_failure(self, mock_get_key, mock_client_class):
+        """
+        Given: Erreur lors de l'appel à l'API WakaTime
+        When: Appel de formation_step()
+        Then: Lève WakaTimeError après avoir affiché le message
+        """
+        mock_get_key.return_value = "test-key"
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.side_effect = WakaTimeError("API Error")
+
+        with pytest.raises(WakaTimeError):
+            formation_step()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    def test_raises_error_on_auth_failure(self, mock_get_key, mock_client_class):
+        """
+        Given: Erreur d'authentification avec l'API WakaTime
+        When: Appel de formation_step()
+        Then: Lève WakaTimeAuthError après avoir affiché le message
+        """
+        mock_get_key.return_value = "invalid-key"
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.side_effect = WakaTimeAuthError("Invalid API key")
+
+        with pytest.raises(WakaTimeAuthError):
+            formation_step()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    @patch("src.lms.steps.formation.datetime")
+    def test_displays_languages_table_when_available(
+        self, mock_datetime, mock_get_key, mock_client_class
+    ):
+        """
+        Given: Statistiques avec plusieurs langages
+        When: Appel de formation_step()
+        Then: Affiche le tableau des langages
+        """
+        mock_get_key.return_value = "test-key"
+        mock_datetime.now.return_value = datetime(2024, 1, 15, 15, 0)
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.return_value = {
+            "total_seconds": 7200,
+            "languages": [
+                {"name": "Python", "total_seconds": 5400, "percent": 75.0},
+                {"name": "JavaScript", "total_seconds": 1800, "percent": 25.0},
+            ],
+            "categories": [],
+        }
+
+        formation_step()
+
+        mock_client.get_today_stats.assert_called_once()
+
+    @patch("src.lms.steps.formation.WakaTimeClient")
+    @patch("src.lms.steps.formation.get_api_key_from_env")
+    @patch("src.lms.steps.formation.datetime")
+    def test_handles_zero_coding_time(self, mock_datetime, mock_get_key, mock_client_class):
+        """
+        Given: Aucune activité de code aujourd'hui
+        When: Appel de formation_step()
+        Then: Affiche les statistiques avec 0 temps
+        """
+        mock_get_key.return_value = "test-key"
+        mock_datetime.now.return_value = datetime(2024, 1, 15, 10, 0)
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_today_stats.return_value = {
+            "total_seconds": 0,
+            "languages": [],
+            "categories": [],
+        }
+
+        formation_step()
+
+        mock_client.get_today_stats.assert_called_once()


### PR DESCRIPTION
## Description
Intégration du client WakaTime dans l'étape Formation pour afficher les statistiques de temps de code.

## Changements
- **src/lms/steps/formation.py** : Étape Formation complète
  - Affichage des statistiques du jour (temps total, langage principal, catégorie)
  - Tableau détaillé des langages utilisés (top 5 avec %)
  - Alerte si < 2h de code avant 17h
  - Gestion des erreurs API (401, 429, timeout, network)
- **tests/lms/steps/formation_test.py** : 22 tests, 100% coverage

## Tests
```bash
python -m pytest tests/lms/steps/formation_test.py
# 22 passed, 100% coverage
```

## Closes
Closes #13