### PR TITLE
docs: Configuration .env (Issue #14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# SkillOps LMS - Configuration Environnement
+# Copier ce fichier vers .env et remplir les valeurs
+
+# WakaTime API Key
+# Obtenir votre clé API sur : https://wakatime.com/settings/account
+# Format : waka_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+WAKATIME_API_KEY=your_wakatime_api_key_here
+
+# Anki Connect URL (optionnel)
+# Par défaut : http://localhost:8765
+# ANKI_CONNECT_URL=http://localhost:8765
+
+# Chemin de stockage des données (optionnel)
+# Par défaut : ~/.local/share/skillops
+# STORAGE_PATH=/path/to/your/storage

--- a/README.md
+++ b/README.md
@@ -161,16 +161,36 @@ source .venv/bin/activate
 # 4. Installer les dépendances
 pip install -r requirements.txt
 
-# 5. Vérifier l'installation
+# 5. Configuration des API keys (REQUIS)
+cp .env.example .env
+# Éditer .env et configurer au minimum :
+#   - WAKATIME_API_KEY (https://wakatime.com/settings/account)
+
+# 6. Vérifier l'installation
 python -m pytest tests/ -v
 
-# 6. Configuration des secrets (optionnel pour dev)
-cp .env.example .env
-# Éditer .env avec vos API keys (WakaTime, Gemini, GitHub, Telegram)
-
 # 7. Lancer le CLI
-python src/lms/main.py
+python src/lms/main.py start
 ```
+
+### 🔑 Configuration des API Keys
+
+**WakaTime (Obligatoire pour l'étape Formation)**
+
+1. Créer un compte sur [WakaTime](https://wakatime.com)
+2. Aller dans [Settings → Account](https://wakatime.com/settings/account)
+3. Copier votre "Secret API Key"
+4. Ajouter dans `.env` :
+   ```bash
+   WAKATIME_API_KEY=waka_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+   ```
+
+**Autres APIs (Optionnelles - Prévues Sprint 2+)**
+- **Gemini AI** : Pour génération de questions/réponses contextuelles
+- **GitHub Token** : Pour automatisation du portfolio
+- **Telegram Bot** : Pour notifications quotidiennes
+
+Voir `.env.example` pour la liste complète.
 
 ### Structure du Projet
 


### PR DESCRIPTION
## Description
Ajout de la configuration .env et documentation pour les API keys.

## Changements
- **.env.example** : Template de configuration
  - WAKATIME_API_KEY (obligatoire)
  - ANKI_CONNECT_URL (optionnel)
  - STORAGE_PATH (optionnel)
- **README.md** : Section "Configuration des API Keys"
  - Instructions étape par étape pour WakaTime
  - Lien vers settings WakaTime
  - Format de la clé API

## Notes
- .env déjà présent dans .gitignore (pas de changement nécessaire)
- Configuration requise pour utiliser l'étape Formation (#13)

## Closes
Closes #14