### PR TITLE
feat(reinforce): Étape Reinforce (Issue #16)

### DIFF
--- a/src/lms/steps/__init__.py
+++ b/src/lms/steps/__init__.py
@@ -1,7 +1,8 @@
 """Steps module - Contains all LMS workflow steps."""
 
 from src.lms.steps.formation import formation_step
+from src.lms.steps.reinforce import reinforce_step
 from src.lms.steps.review import review_step
 
-__all__ = ["formation_step", "review_step"]
+__all__ = ["formation_step", "reinforce_step", "review_step"]
 

--- a/src/lms/steps/reinforce.py
+++ b/src/lms/steps/reinforce.py
@@ -1,0 +1,282 @@
+"""Étape Reinforce - Pratique d'exercices avec suivi de progression."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+from ..display import (
+    display_error_message,
+    display_info_panel,
+    display_section_header,
+    display_success_message,
+    format_time_duration,
+)
+from ..persistence import ProgressManager
+
+console = Console()
+
+
+def get_storage_path() -> Path:
+    """
+    Récupère le chemin de stockage depuis l'environnement ou utilise le défaut.
+
+    Returns:
+        Path: Chemin absolu vers le répertoire de stockage
+    """
+    storage_path_str = os.getenv("STORAGE_PATH", str(Path.home() / ".local/share/skillops"))
+    return Path(storage_path_str).expanduser().absolute()
+
+
+def get_available_exercises() -> List[Dict[str, str]]:
+    """
+    Retourne la liste des exercices disponibles.
+
+    Returns:
+        List[Dict]: Liste des exercices avec id, titre, difficulté, durée estimée
+    """
+    return [
+        {
+            "id": "docker-basics",
+            "title": "Docker Basics - Créer et gérer des conteneurs",
+            "difficulty": "Débutant",
+            "estimated_time": "15min",
+        },
+        {
+            "id": "k8s-pods",
+            "title": "Kubernetes - Déploiement de Pods",
+            "difficulty": "Intermédiaire",
+            "estimated_time": "30min",
+        },
+        {
+            "id": "terraform-aws",
+            "title": "Terraform - Infrastructure AWS",
+            "difficulty": "Intermédiaire",
+            "estimated_time": "45min",
+        },
+        {
+            "id": "ansible-playbook",
+            "title": "Ansible - Configuration automatisée",
+            "difficulty": "Débutant",
+            "estimated_time": "20min",
+        },
+        {
+            "id": "cicd-pipeline",
+            "title": "CI/CD - Pipeline GitHub Actions",
+            "difficulty": "Avancé",
+            "estimated_time": "60min",
+        },
+    ]
+
+
+def display_exercises_table(exercises: List[Dict[str, str]]) -> None:
+    """
+    Affiche un tableau des exercices disponibles.
+
+    Args:
+        exercises: Liste des exercices à afficher
+    """
+    table = Table(title="📝 Exercices disponibles", show_header=True, header_style="bold cyan")
+    table.add_column("ID", style="cyan", width=20)
+    table.add_column("Titre", style="white", width=40)
+    table.add_column("Difficulté", style="yellow", width=15)
+    table.add_column("Durée", style="green", width=10)
+
+    for exercise in exercises:
+        table.add_row(
+            exercise["id"],
+            exercise["title"],
+            exercise["difficulty"],
+            exercise["estimated_time"],
+        )
+
+    console.print()
+    console.print(table)
+    console.print()
+
+
+def get_exercise_progress(exercise_id: str, storage_path: Path) -> Optional[Dict]:
+    """
+    Récupère la progression d'un exercice depuis le stockage.
+
+    Args:
+        exercise_id: Identifiant de l'exercice
+        storage_path: Chemin vers le répertoire de stockage
+
+    Returns:
+        Optional[Dict]: Données de progression ou None si non trouvé
+    """
+    progress_manager = ProgressManager(storage_path)
+    today = datetime.now().strftime("%Y-%m-%d")
+    today_progress = progress_manager.load(today)
+
+    if today_progress and "reinforce" in today_progress:
+        exercises = today_progress["reinforce"].get("exercises", [])
+        for exercise in exercises:
+            if exercise.get("id") == exercise_id:
+                return exercise
+
+    return None
+
+
+def save_exercise_progress(
+    exercise_id: str,
+    title: str,
+    duration_seconds: int,
+    completed: bool,
+    storage_path: Path,
+) -> None:
+    """
+    Sauvegarde la progression d'un exercice.
+
+    Args:
+        exercise_id: Identifiant de l'exercice
+        title: Titre de l'exercice
+        duration_seconds: Durée en secondes
+        completed: Si l'exercice est terminé
+        storage_path: Chemin vers le répertoire de stockage
+    """
+    progress_manager = ProgressManager(storage_path)
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    # Charger la progression existante
+    progress = progress_manager.load(today) or {}
+
+    # Initialiser reinforce s'il n'existe pas
+    if "reinforce" not in progress:
+        progress["reinforce"] = {"exercises": [], "total_time": 0}
+
+    # Vérifier si l'exercice existe déjà
+    exercises = progress["reinforce"]["exercises"]
+    existing_exercise = None
+    for i, ex in enumerate(exercises):
+        if ex.get("id") == exercise_id:
+            existing_exercise = i
+            break
+
+    exercise_data = {
+        "id": exercise_id,
+        "title": title,
+        "duration_seconds": duration_seconds,
+        "completed": completed,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    if existing_exercise is not None:
+        # Mettre à jour l'exercice existant
+        exercises[existing_exercise] = exercise_data
+    else:
+        # Ajouter un nouvel exercice
+        exercises.append(exercise_data)
+
+    # Mettre à jour le temps total
+    progress["reinforce"]["total_time"] = sum(ex["duration_seconds"] for ex in exercises)
+
+    # Sauvegarder
+    progress_manager.save(today, progress)
+
+
+def record_exercise_session(exercise: Dict[str, str], storage_path: Path) -> None:
+    """
+    Enregistre une session d'exercice avec chronomètre et validation.
+
+    Args:
+        exercise: Dictionnaire avec les données de l'exercice
+        storage_path: Chemin vers le répertoire de stockage
+    """
+    display_info_panel(
+        f"Exercice : {exercise['title']}",
+        f"Difficulté : {exercise['difficulty']}\n"
+        f"Durée estimée : {exercise['estimated_time']}",
+    )
+
+    console.print("\n[cyan]Appuyez sur Entrée quand vous avez terminé l'exercice...[/cyan]")
+    start_time = datetime.now()
+    input()  # Attendre que l'utilisateur appuie sur Entrée
+
+    end_time = datetime.now()
+    duration = int((end_time - start_time).total_seconds())
+
+    # Demander si l'exercice est terminé
+    completed = Confirm.ask("\n✅ Avez-vous terminé l'exercice avec succès ?", default=True)
+
+    # Sauvegarder la progression
+    save_exercise_progress(
+        exercise["id"],
+        exercise["title"],
+        duration,
+        completed,
+        storage_path,
+    )
+
+    if completed:
+        display_success_message(
+            "Exercice terminé !",
+            f"Durée : {format_time_duration(duration)}\n"
+            f"Exercice : {exercise['title']}\n\n"
+            f"Excellent travail ! 🎉",
+        )
+    else:
+        display_info_panel(
+            "Session enregistrée",
+            f"Durée : {format_time_duration(duration)}\n"
+            f"Exercice : {exercise['title']}\n\n"
+            f"Continuez à pratiquer ! 💪",
+        )
+
+
+def reinforce_step(storage_path: Optional[Path] = None) -> None:
+    """
+    Exécute l'étape Reinforce : pratique d'exercices avec suivi de progression.
+
+    Cette fonction:
+    1. Affiche la liste des exercices disponibles
+    2. Permet de choisir un exercice
+    3. Enregistre la session avec chronomètre
+    4. Sauvegarde la progression
+
+    Args:
+        storage_path: Chemin vers le répertoire de stockage (optionnel)
+    """
+    display_section_header("Reinforce - Pratique", "💪")
+
+    # Déterminer le chemin de stockage
+    if storage_path is None:
+        storage_path = get_storage_path()
+
+    # Récupérer les exercices disponibles
+    exercises = get_available_exercises()
+
+    # Afficher le tableau
+    display_exercises_table(exercises)
+
+    # Demander à l'utilisateur de choisir un exercice
+    console.print(
+        "[cyan]Choisissez un exercice en entrant son ID (ou 'q' pour quitter) :[/cyan]"
+    )
+    exercise_id = Prompt.ask("ID de l'exercice")
+
+    if exercise_id.lower() == "q":
+        console.print("\n[yellow]À bientôt ! 👋[/yellow]\n")
+        return
+
+    # Trouver l'exercice sélectionné
+    selected_exercise = None
+    for exercise in exercises:
+        if exercise["id"] == exercise_id:
+            selected_exercise = exercise
+            break
+
+    if selected_exercise is None:
+        display_error_message(
+            "Exercice introuvable",
+            f"L'ID '{exercise_id}' ne correspond à aucun exercice disponible.",
+        )
+        return
+
+    # Enregistrer la session
+    record_exercise_session(selected_exercise, storage_path)

--- a/tests/lms/steps/reinforce_test.py
+++ b/tests/lms/steps/reinforce_test.py
@@ -1,0 +1,415 @@
+"""Tests pour l'étape Reinforce."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch, mock_open
+
+import pytest
+from rich.table import Table
+
+from src.lms.steps.reinforce import (
+    display_exercises_table,
+    get_available_exercises,
+    get_exercise_progress,
+    get_storage_path,
+    record_exercise_session,
+    reinforce_step,
+    save_exercise_progress,
+)
+
+
+class TestGetStoragePath:
+    """Tests pour get_storage_path()."""
+
+    def test_returns_default_path_when_no_env_var(self, monkeypatch):
+        """
+        Given: Variable STORAGE_PATH non définie
+        When: Appel de get_storage_path()
+        Then: Retourne le chemin par défaut ~/.local/share/skillops
+        """
+        monkeypatch.delenv("STORAGE_PATH", raising=False)
+        result = get_storage_path()
+        expected = Path.home() / ".local/share/skillops"
+        assert result == expected
+
+    def test_returns_custom_path_when_env_var_set(self, monkeypatch):
+        """
+        Given: Variable STORAGE_PATH définie
+        When: Appel de get_storage_path()
+        Then: Retourne le chemin configuré
+        """
+        custom_path = "/tmp/custom-storage"
+        monkeypatch.setenv("STORAGE_PATH", custom_path)
+        result = get_storage_path()
+        assert result == Path(custom_path)
+
+
+class TestGetAvailableExercises:
+    """Tests pour get_available_exercises()."""
+
+    def test_returns_list_of_exercises(self):
+        """
+        Given: Aucun paramètre
+        When: Appel de get_available_exercises()
+        Then: Retourne une liste d'exercices avec id, titre, difficulté, durée
+        """
+        exercises = get_available_exercises()
+        assert isinstance(exercises, list)
+        assert len(exercises) > 0
+
+        # Vérifier la structure du premier exercice
+        first_exercise = exercises[0]
+        assert "id" in first_exercise
+        assert "title" in first_exercise
+        assert "difficulty" in first_exercise
+        assert "estimated_time" in first_exercise
+
+    def test_exercises_have_valid_ids(self):
+        """
+        Given: Liste d'exercices
+        When: Vérification des IDs
+        Then: Tous les IDs sont des strings non-vides et uniques
+        """
+        exercises = get_available_exercises()
+        ids = [ex["id"] for ex in exercises]
+
+        # Tous les IDs sont des strings non-vides
+        assert all(isinstance(id, str) and id for id in ids)
+
+        # Tous les IDs sont uniques
+        assert len(ids) == len(set(ids))
+
+
+class TestDisplayExercisesTable:
+    """Tests pour display_exercises_table()."""
+
+    def test_displays_table_with_exercises(self):
+        """
+        Given: Liste d'exercices
+        When: Appel de display_exercises_table()
+        Then: Affiche un tableau (pas d'exception)
+        """
+        exercises = [
+            {
+                "id": "test-1",
+                "title": "Test Exercise",
+                "difficulty": "Easy",
+                "estimated_time": "10min",
+            }
+        ]
+        # Should not raise exception
+        display_exercises_table(exercises)
+
+    def test_displays_empty_table(self):
+        """
+        Given: Liste vide
+        When: Appel de display_exercises_table()
+        Then: Affiche un tableau vide (pas d'exception)
+        """
+        exercises = []
+        # Should not raise exception
+        display_exercises_table(exercises)
+
+
+class TestSaveExerciseProgress:
+    """Tests pour save_exercise_progress()."""
+
+    @patch("src.lms.steps.reinforce.ProgressManager")
+    def test_saves_new_exercise(self, mock_pm_class, tmp_path):
+        """
+        Given: Nouvel exercice à sauvegarder
+        When: Appel de save_exercise_progress()
+        Then: Sauvegarde l'exercice avec les bonnes données
+        """
+        # Setup
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.load.return_value = None  # Pas de progression existante
+
+        # Execute
+        save_exercise_progress("test-id", "Test Exercise", 600, True, tmp_path)
+
+        # Verify
+        mock_pm.save.assert_called_once()
+        call_args = mock_pm.save.call_args
+        # date should be today's date in YYYY-MM-DD format
+        assert isinstance(call_args[0][0], str)
+        progress = call_args[0][1]  # progress data
+
+        assert "reinforce" in progress
+        assert len(progress["reinforce"]["exercises"]) == 1
+        assert progress["reinforce"]["exercises"][0]["id"] == "test-id"
+        assert progress["reinforce"]["exercises"][0]["completed"] is True
+        assert progress["reinforce"]["total_time"] == 600
+
+    @patch("src.lms.steps.reinforce.ProgressManager")
+    def test_updates_existing_exercise(self, mock_pm_class, tmp_path):
+        """
+        Given: Exercice existant à mettre à jour
+        When: Appel de save_exercise_progress() avec le même ID
+        Then: Met à jour l'exercice existant au lieu d'en créer un nouveau
+        """
+        # Setup
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.load.return_value = {
+            "reinforce": {
+                "exercises": [
+                    {
+                        "id": "test-id",
+                        "title": "Old Title",
+                        "duration_seconds": 300,
+                        "completed": False,
+                        "timestamp": "2024-01-15T09:00:00",
+                    }
+                ],
+                "total_time": 300,
+            }
+        }
+
+        # Execute
+        save_exercise_progress("test-id", "New Title", 600, True, tmp_path)
+
+        # Verify
+        call_args = mock_pm.save.call_args
+        progress = call_args[0][1]
+
+        # Should still have only 1 exercise (updated, not added)
+        assert len(progress["reinforce"]["exercises"]) == 1
+        assert progress["reinforce"]["exercises"][0]["title"] == "New Title"
+        assert progress["reinforce"]["exercises"][0]["duration_seconds"] == 600
+        assert progress["reinforce"]["exercises"][0]["completed"] is True
+        assert progress["reinforce"]["total_time"] == 600
+
+
+class TestGetExerciseProgress:
+    """Tests pour get_exercise_progress()."""
+
+    @patch("src.lms.steps.reinforce.ProgressManager")
+    def test_returns_progress_when_found(self, mock_pm_class, tmp_path):
+        """
+        Given: Exercice avec progression sauvegardée
+        When: Appel de get_exercise_progress()
+        Then: Retourne les données de progression
+        """
+        # Setup
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.load.return_value = {
+            "reinforce": {
+                "exercises": [
+                    {
+                        "id": "test-id",
+                        "title": "Test Exercise",
+                        "duration_seconds": 600,
+                        "completed": True,
+                    }
+                ]
+            }
+        }
+
+        # Execute
+        result = get_exercise_progress("test-id", tmp_path)
+
+        # Verify
+        assert result is not None
+        assert result["id"] == "test-id"
+        assert result["completed"] is True
+
+    @patch("src.lms.steps.reinforce.ProgressManager")
+    def test_returns_none_when_not_found(self, mock_pm_class, tmp_path):
+        """
+        Given: Exercice sans progression
+        When: Appel de get_exercise_progress()
+        Then: Retourne None
+        """
+        # Setup
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.load.return_value = None
+
+        # Execute
+        result = get_exercise_progress("nonexistent", tmp_path)
+
+        # Verify
+        assert result is None
+
+
+class TestRecordExerciseSession:
+    """Tests pour record_exercise_session()."""
+
+    @patch("src.lms.steps.reinforce.save_exercise_progress")
+    @patch("src.lms.steps.reinforce.Confirm")
+    @patch("src.lms.steps.reinforce.datetime")
+    @patch("builtins.input", return_value="")
+    def test_records_completed_exercise(
+        self, mock_input, mock_datetime, mock_confirm, mock_save, tmp_path
+    ):
+        """
+        Given: Utilisateur complète un exercice
+        When: Appel de record_exercise_session()
+        Then: Sauvegarde avec completed=True
+        """
+        # Setup
+        start_time = datetime(2024, 1, 15, 10, 0)
+        end_time = datetime(2024, 1, 15, 10, 10)  # 10 minutes plus tard
+
+        mock_datetime.now.side_effect = [start_time, end_time]
+        mock_confirm.ask.return_value = True
+
+        exercise = {
+            "id": "test-id",
+            "title": "Test Exercise",
+            "difficulty": "Easy",
+            "estimated_time": "10min",
+        }
+
+        # Execute
+        record_exercise_session(exercise, tmp_path)
+
+        # Verify
+        mock_save.assert_called_once()
+        call_args = mock_save.call_args[0]
+        assert call_args[0] == "test-id"
+        assert call_args[1] == "Test Exercise"
+        assert call_args[2] == 600  # 10 minutes = 600 seconds
+        assert call_args[3] is True  # completed
+        assert call_args[4] == tmp_path
+
+    @patch("src.lms.steps.reinforce.save_exercise_progress")
+    @patch("src.lms.steps.reinforce.Confirm")
+    @patch("src.lms.steps.reinforce.datetime")
+    @patch("builtins.input", return_value="")
+    def test_records_incomplete_exercise(
+        self, mock_input, mock_datetime, mock_confirm, mock_save, tmp_path
+    ):
+        """
+        Given: Utilisateur ne complète pas l'exercice
+        When: Appel de record_exercise_session()
+        Then: Sauvegarde avec completed=False
+        """
+        # Setup
+        start_time = datetime(2024, 1, 15, 10, 0)
+        end_time = datetime(2024, 1, 15, 10, 5)  # 5 minutes plus tard
+
+        mock_datetime.now.side_effect = [start_time, end_time]
+        mock_confirm.ask.return_value = False
+
+        exercise = {
+            "id": "test-id",
+            "title": "Test Exercise",
+            "difficulty": "Hard",
+            "estimated_time": "30min",
+        }
+
+        # Execute
+        record_exercise_session(exercise, tmp_path)
+
+        # Verify
+        call_args = mock_save.call_args[0]
+        assert call_args[2] == 300  # 5 minutes = 300 seconds
+        assert call_args[3] is False  # not completed
+
+
+class TestReinforceStep:
+    """Tests pour reinforce_step()."""
+
+    @patch("src.lms.steps.reinforce.record_exercise_session")
+    @patch("src.lms.steps.reinforce.Prompt")
+    @patch("src.lms.steps.reinforce.get_available_exercises")
+    def test_selects_and_records_exercise(
+        self, mock_exercises, mock_prompt, mock_record, tmp_path
+    ):
+        """
+        Given: Utilisateur choisit un exercice valide
+        When: Appel de reinforce_step()
+        Then: Enregistre la session de l'exercice
+        """
+        # Setup
+        mock_exercises.return_value = [
+            {
+                "id": "test-1",
+                "title": "Test Exercise",
+                "difficulty": "Easy",
+                "estimated_time": "10min",
+            }
+        ]
+        mock_prompt.ask.return_value = "test-1"
+
+        # Execute
+        reinforce_step(tmp_path)
+
+        # Verify
+        mock_record.assert_called_once()
+        recorded_exercise = mock_record.call_args[0][0]
+        assert recorded_exercise["id"] == "test-1"
+
+    @patch("src.lms.steps.reinforce.record_exercise_session")
+    @patch("src.lms.steps.reinforce.Prompt")
+    @patch("src.lms.steps.reinforce.get_available_exercises")
+    def test_exits_when_user_quits(self, mock_exercises, mock_prompt, mock_record, tmp_path):
+        """
+        Given: Utilisateur tape 'q' pour quitter
+        When: Appel de reinforce_step()
+        Then: Quitte sans enregistrer de session
+        """
+        # Setup
+        mock_exercises.return_value = []
+        mock_prompt.ask.return_value = "q"
+
+        # Execute
+        reinforce_step(tmp_path)
+
+        # Verify
+        mock_record.assert_not_called()
+
+    @patch("src.lms.steps.reinforce.record_exercise_session")
+    @patch("src.lms.steps.reinforce.Prompt")
+    @patch("src.lms.steps.reinforce.get_available_exercises")
+    def test_shows_error_for_invalid_id(
+        self, mock_exercises, mock_prompt, mock_record, tmp_path
+    ):
+        """
+        Given: Utilisateur entre un ID invalide
+        When: Appel de reinforce_step()
+        Then: Affiche un message d'erreur et ne lance pas de session
+        """
+        # Setup
+        mock_exercises.return_value = [
+            {"id": "test-1", "title": "Test", "difficulty": "Easy", "estimated_time": "10min"}
+        ]
+        mock_prompt.ask.return_value = "invalid-id"
+
+        # Execute
+        reinforce_step(tmp_path)
+
+        # Verify
+        mock_record.assert_not_called()
+
+    @patch("src.lms.steps.reinforce.get_storage_path")
+    @patch("src.lms.steps.reinforce.record_exercise_session")
+    @patch("src.lms.steps.reinforce.Prompt")
+    @patch("src.lms.steps.reinforce.get_available_exercises")
+    def test_uses_default_storage_path_when_none(
+        self, mock_exercises, mock_prompt, mock_record, mock_storage
+    ):
+        """
+        Given: Aucun storage_path fourni
+        When: Appel de reinforce_step()
+        Then: Utilise get_storage_path() pour obtenir le chemin par défaut
+        """
+        # Setup
+        mock_exercises.return_value = [
+            {"id": "test-1", "title": "Test", "difficulty": "Easy", "estimated_time": "10min"}
+        ]
+        mock_prompt.ask.return_value = "test-1"
+        mock_storage.return_value = Path("/default/path")
+
+        # Execute
+        reinforce_step()  # No storage_path argument
+
+        # Verify
+        mock_storage.assert_called_once()
+        # record_exercise_session should be called with the default path
+        assert mock_record.call_args[0][1] == Path("/default/path")


### PR DESCRIPTION
## Description
Implémentation de l'étape Reinforce pour la pratique d'exercices DevOps avec suivi de progression.

## Changements
- **src/lms/steps/reinforce.py** :
  - Catalogue de 5 exercices DevOps (Docker, K8s, Terraform, Ansible, CI/CD)
  - Interface interactive avec sélection par ID
  - Chronomètre automatique de session
  - Validation de complétion
  - Sauvegarde dans ProgressManager (durée, status)
  - Récupération historique par exercice
- **tests/lms/steps/reinforce_test.py** : 16 tests, 100% coverage

## Fonctionnalités
- **Tableau d'exercices** : ID, titre, difficulté, durée estimée
- **Session tracking** : Chronomètre start/stop automatique
- **Progression** : Sauvegarde dans storage/progress avec timestamp
- **Historique** : Récupération des sessions précédentes

## Tests
```bash
python -m pytest tests/lms/steps/reinforce_test.py
# 16 passed, 100% coverage (86/86 statements)
```

## Closes
Closes #16